### PR TITLE
Dev fix bug and deprecation funtion.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: arabic2kansuji
 Type: Package
 Title: Convert Arabic numerals to kansuji
-Version: 0.0.0.9902
+Version: 0.0.0.9910
 Author: indenkun
 Maintainer: indenkun <blog@indenkun.hagenabolg.com>
 Description: Converts a given arabic mumerals to kansuji.

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,6 @@
 
 export(arabic2kansuji)
 export(arabic2kansuji_all)
-export(arabic2kansuji_cal)
 export(arabic2kansuji_num)
 importFrom(purrr,map)
 importFrom(purrr,map_chr)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# arabic2kansuji 0.0.0.9910
+
+## BUG FIXES
+
+* Problem solved with multiple functions that could not be converted Arabic numerals to kansuji correctly.
+
+## Deprecation
+
+* The functions of `arabic2kansuji_num`, which converts single Arabic numerals to kansuji, and `arabic2kansuji_cal`, which accepts multiple Arabic numerals and converts them to kansuji are duplicated, so `arabic2kansuji_num` is now a function that converts multiple Arabic numerals to kansuji, and functions that accept single Arabic numerals can no longer be used (but existing in code as `arabic2kansuji_cal`).
+
 # arabic2kansuji 0.0.0.9902
 
 ## BUG FIXES

--- a/R/arabic2kansuji.R
+++ b/R/arabic2kansuji.R
@@ -50,15 +50,12 @@ arabic2kansuji <- function(str,
 
 }
 
-#' @param num Input only one number.
 #' @importFrom purrr reduce
 #' @importFrom stringr boundary
 #' @importFrom stringr str_flatten
 #' @importFrom stats na.omit
-#' @rdname arabic2kansuji
-#' @export
 #'
-arabic2kansuji_num <- function(num, ...){
+arabic2kansuji_cal <- function(num, ...){
   if(length(num) > 1) stop( writeLines("only one number can convert to kansuji. \nuse `arabic2kansuji_cal` to convert to over 2 numbers."))
   if(!is.numeric(num)) stop("only number can convert to kansuji.")
 
@@ -154,13 +151,13 @@ arabic2kansuji_num <- function(num, ...){
 }
 
 
-#' @param nums Input only number. Accept more than one number.
+#' @param num Input only number. Accept more than one number.
 #' @importFrom purrr map_chr
 #' @rdname arabic2kansuji
 #' @export
 #'
-arabic2kansuji_cal <- function(nums, ...){
-  unlist(purrr::map_chr(nums, arabic2kansuji_num, ...))
+arabic2kansuji_num <- function(num, ...){
+  unlist(purrr::map(num, arabic2kansuji_cal, ...))
 }
 
 #' @importFrom stringr str_split
@@ -168,7 +165,7 @@ arabic2kansuji_cal <- function(nums, ...){
 #' @importFrom stringr str_replace_all
 #' @importFrom stats na.omit
 #'
-arabic2kansuji_all_num <- function(str, widths = c("halfwidth", "all")){
+arabic2kansuji_all_num <- function(str, widths = c("halfwidth", "all"), ...){
   widths <- match.arg(widths)
 
   str_row <- str
@@ -184,15 +181,15 @@ arabic2kansuji_all_num <- function(str, widths = c("halfwidth", "all")){
     str <- stringr::str_replace_all(str, arabicn_half)
   }
 
-  doc_num <- stringr::str_split(str, pattern = "[^0123456789]")[[1]]
-  doc_num[doc_num == ""] <- NA
-  doc_num <- stats::na.omit(doc_num)
-  doc_kansuji <- arabic2kansuji_cal(as.numeric(doc_num))
+  str_num <- stringr::str_split(str, pattern = "[^0123456789]")[[1]]
+  str_num[str_num == ""] <- NA
+  str_num <- stats::na.omit(str_num)
+  str_kansuji <- arabic2kansuji_num(as.numeric(str_num), ...)
 
-  if(length(doc_num) == 0) return(str_row)
+  if(length(str_num) == 0) return(str_row)
 
-  for(i in 1:length(doc_num)){
-    str <- stringr::str_replace(str, pattern = doc_num[i], replacement = doc_kansuji[i])
+  for(i in 1:length(str_num)){
+    str <- stringr::str_replace(str, pattern = str_num[i], replacement = str_kansuji[i])
   }
 
   return(str)
@@ -202,11 +199,12 @@ arabic2kansuji_all_num <- function(str, widths = c("halfwidth", "all")){
 #'               half-width numbers ("halfwidth") or both half-width and
 #'               full-width numbers ("all") when converting Arabic numbers to
 #'               kansuji.
+#' @param ...    Other arguments to carry over to `arabic2kansuji()`
 #' @importFrom purrr map
 #' @rdname arabic2kansuji
 #' @export
 #'
 arabic2kansuji_all <- function(str, widths = c("halfwidth", "all"), ...){
   widths <- match.arg(widths)
-  unlist(purrr::map2(str, widths, arabic2kansuji_all_num), ...)
+  unlist(purrr::map2(str, widths, arabic2kansuji_all_num, ...))
 }

--- a/R/arabic2kansuji.R
+++ b/R/arabic2kansuji.R
@@ -199,7 +199,7 @@ arabic2kansuji_all_num <- function(str, widths = c("halfwidth", "all"), ...){
 #'               half-width numbers ("halfwidth") or both half-width and
 #'               full-width numbers ("all") when converting Arabic numbers to
 #'               kansuji.
-#' @param ...    Other arguments to carry over to `arabic2kansuji()`
+#' @param ...    Other arguments to carry over to `arabic2kansuji()`.
 #' @importFrom purrr map
 #' @rdname arabic2kansuji
 #' @export

--- a/README.Rmd
+++ b/README.Rmd
@@ -107,17 +107,11 @@ Some values (e.g. 10 to the power of 10, such as 10 to the power of 10) cannot b
 arabic2kansuji_num(10000000000)
 ```
 
-### `arabic2kansuji_call`
-
-`arabic2kansuji_num` does not accept more than one half-width Arabic numeral, but `arabic2kansuji_cal` accepts two or more Arabic numerals, calculates and converts them to kansuji.
+`arabic2kansuji_num`  accepts two or more Arabic numerals, calculates and converts them to kansuji.
 
 ```{r, error=TRUE}
 x <- c(123, 456, 789)
 arabic2kansuji_num(x)
-```
-
-```{r}
-arabic2kansuji_cal(x)
 ```
 
 ### `arabic2kansuji_all`
@@ -137,11 +131,26 @@ x <- c("昭和64年は1989年1月7日までです。", "平成31年は2019年4�
 arabic2kansuji_all(x)
 ```
 
+
+`arabic2kansuji_all` can also convert Arabic numerals and kansuji intended for digits to represent a single number, such as 1億2345万 intended for 一億二千三百四十五万. This is a kind of side effect that happens when Arabic numbers are converted to kansuji because the readings are just the same.
+
+```{r}
+arabic2kansuji_all("1億2345万")
+```
+
 ## Improrts packges
 
 * `{purrr}`
 * `{stringr}`
 * `{stats}`
+
+## Known Issue
+
+* `arabic2kansuji_all` a combination of Arabic and kansuji representing a single number of digits, such as tens or billions, but not including the next upper tens or billions of digits, such as 12345万, which is intended to be 一億二千三百四十五万, would be valued at 一万二千三百四十五 in the Arabic numeral place and would not appear in the intended form. There is currently no error on this issue.
+
+```{r}
+arabic2kansuji_all("12345万")
+```
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ a string) to kansuji.
 
 ``` r
 arabic2kansuji_num("124271318人")
-#> Error in arabic2kansuji_num("124271318人"): only number can convert to kansuji.
+#> Error in .f(.x[[i]], ...): only number can convert to kansuji.
 ```
 
 Use `arabic2kansuji_all` to calculate and convert Arabic numerals to
@@ -109,7 +109,7 @@ processing may not be performed correctly due to problems on the R.
 
 ``` r
 arabic2kansuji_num(1234567890123456789)
-#> Warning in arabic2kansuji_num(1234567890123456768): too long to convert.
+#> Warning in .f(.x[[i]], ...): too long to convert.
 #> [1] "百二十三京四千五百六十七兆八千九百一億二千三百四十五万六千七百六十八"
 ```
 
@@ -127,25 +127,15 @@ processing, so there are no plans to fix it as the present time.
 
 ``` r
 arabic2kansuji_num(10000000000)
-#> Error in arabic2kansuji_num(1e+10): too large number and not good shape to convert.
+#> Error in .f(.x[[i]], ...): too large number and not good shape to convert.
 ```
 
-### `arabic2kansuji_call`
-
-`arabic2kansuji_num` does not accept more than one half-width Arabic
-numeral, but `arabic2kansuji_cal` accepts two or more Arabic numerals,
-calculates and converts them to kansuji.
+`arabic2kansuji_num` accepts two or more Arabic numerals, calculates and
+converts them to kansuji.
 
 ``` r
 x <- c(123, 456, 789)
 arabic2kansuji_num(x)
-#> only one number can convert to kansuji. 
-#> use `arabic2kansuji_cal` to convert to over 2 numbers.
-#> Error in arabic2kansuji_num(x):
-```
-
-``` r
-arabic2kansuji_cal(x)
 #> [1] "百二十三"   "四百五十六" "七百八十九"
 ```
 
@@ -177,11 +167,39 @@ arabic2kansuji_all(x)
 #> [2] "平成三十一年は二千十九年四月三十日までです。"
 ```
 
+`arabic2kansuji_all` can also convert Arabic numerals and kansuji
+intended for digits to represent a single number, such as 1億2345万
+intended for 一億二千三百四十五万. This is a kind of side effect that happens when
+Arabic numbers are converted to kansuji because the readings are just
+the same.
+
+``` r
+arabic2kansuji_all("1億2345万")
+#> [1] "一億二千三百四十五万"
+```
+
 ## Improrts packges
 
   - `{purrr}`
   - `{stringr}`
   - `{stats}`
+
+## Known Issue
+
+  - `arabic2kansuji_all` a combination of Arabic and kansuji
+    representing a single number of digits, such as tens or billions,
+    but not including the next upper tens or billions of digits, such as
+    12345万, which is intended to be 一億二千三百四十五万, would be valued at
+    一万二千三百四十五 in the Arabic numeral place and would not
+    appear in the intended form. There is currently no error on this
+    issue.
+
+<!-- end list -->
+
+``` r
+arabic2kansuji_all("12345万")
+#> [1] "一万二千三百四十五万"
+```
 
 ## Reference
 

--- a/man/arabic2kansuji.Rd
+++ b/man/arabic2kansuji.Rd
@@ -29,7 +29,7 @@ numbers ("all") when converting Arabic numbers to kansuji.}
 
 \item{num}{Input only number. Accept more than one number.}
 
-\item{...}{Other arguments to carry over to `arabic2kansuji()`}
+\item{...}{Other arguments to carry over to `arabic2kansuji()`.}
 
 \item{widths}{Selects whether you want to convert Arabic numbers, only
 half-width numbers ("halfwidth") or both half-width and

--- a/man/arabic2kansuji.Rd
+++ b/man/arabic2kansuji.Rd
@@ -3,7 +3,6 @@
 \name{arabic2kansuji}
 \alias{arabic2kansuji}
 \alias{arabic2kansuji_num}
-\alias{arabic2kansuji_cal}
 \alias{arabic2kansuji_all}
 \title{Convert Arabic numerals to kansuji}
 \usage{
@@ -14,8 +13,6 @@ arabic2kansuji(
 )
 
 arabic2kansuji_num(num, ...)
-
-arabic2kansuji_cal(nums, ...)
 
 arabic2kansuji_all(str, widths = c("halfwidth", "all"), ...)
 }
@@ -30,9 +27,9 @@ half-width numbers ("halfwidth") or only full-width
 numbers ("fullwidth") or both half-width and full-width
 numbers ("all") when converting Arabic numbers to kansuji.}
 
-\item{num}{Input only one number.}
+\item{num}{Input only number. Accept more than one number.}
 
-\item{nums}{Input only number. Accept more than one number.}
+\item{...}{Other arguments to carry over to `arabic2kansuji()`}
 
 \item{widths}{Selects whether you want to convert Arabic numbers, only
 half-width numbers ("halfwidth") or both half-width and


### PR DESCRIPTION
## BUG FIXES

* Problem solved with multiple functions that could not be converted Arabic numerals to kansuji correctly.

## Deprecation

* The functions of `arabic2kansuji_num`, which converts single Arabic numerals to kansuji, and `arabic2kansuji_cal`, which accepts multiple Arabic numerals and converts them to kansuji are duplicated, so `arabic2kansuji_num` is now a function that converts multiple Arabic numerals to kansuji, and functions that accept single Arabic numerals can no longer be used (but existing in code as `arabic2kansuji_cal`).